### PR TITLE
Cleans up the gradle task dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ cache:
 before_script:
   - ./backend/e2e/setup_db.sh
 
-install: ./gradlew yarn assemble
-
 script:
   - ./gradlew check
   - ./backend/e2e/e2e_test.sh

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,8 +18,9 @@ repositories {
 }
 
 processResources {
-    dependsOn(':frontend:build')
-    from(rootProject.project(':frontend').buildDir) {into 'public'}
+    def frontendBuildTask = tasks.findByPath(":frontend:build")
+    dependsOn(frontendBuildTask)
+    from(frontendBuildTask.outputs) {into 'public'}
 }
 
 dependencies {

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -9,6 +9,16 @@ node {
     download = true
 }
 
-task build(type: YarnTask, dependsOn: ['yarnSetup']) {
+task build(type: YarnTask, dependsOn: ['yarn']) {
     args = ['build']
+    inputs.dir(project.file("./src"))
+    inputs.dir(project.file("./node_modules"))
+    outputs.dir(project.buildDir)
+}
+
+task clean {
+    destroyables.register project.buildDir
+    doLast {
+        delete project.buildDir
+    }
 }


### PR DESCRIPTION
This allows us to use the gradle cache for the fronend. Thus the
frontend doesn't need to be recompiled on every build of the backend.